### PR TITLE
Fixes warning for using @tailwind

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,13 @@
+{
+  "extends": "stylelint-config-recommended",
+  "rules": {
+    "at-rule-no-unknown": [ true, {
+      "ignoreAtRules": [
+        "extends",
+        "tailwind"
+      ]
+    }],
+    "block-no-empty": null,
+    "unit-whitelist": ["em", "rem", "s"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7985,6 +7985,12 @@
         }
       }
     },
+    "stylelint-config-recommended": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz",
+      "integrity": "sha512-ajMbivOD7JxdsnlS5945KYhvt7L/HwN6YeYF2BH6kE4UCLJR0YvXMf+2j7nQpJyYLZx9uZzU5G1ZOSBiWAc6yA==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-react": "^7.12.4",
     "parcel-bundler": "^1.12.3",
     "prettier": "^1.16.4",
+    "stylelint-config-recommended": "^2.1.0",
     "tailwindcss": "^0.7.4"
   },
   "dependencies": {


### PR DESCRIPTION
This PR will fix the warning shown below:

![image](https://user-images.githubusercontent.com/3977903/54774110-37030d00-4bc8-11e9-9d99-bbeec745e5dd.png)

## Resources / Articles referenced:

#### Source: https://stackoverflow.com/questions/47607602/how-to-add-a-tailwind-css-rule-to-css-checker
#### Answered by: https://stackoverflow.com/users/6282568/hasusuf
> This is the at-rule-no-unknown rule provided by vscode's built-in list.
> 
> In order to get rid of it you need to do the following:
> 1. Install stylelint extension code --install-extension shinnn.stylelint
> 2. Install stylelint recommended config npm install stylelint-config-recommended --save-dev
> 3. Add these two lines in your vscode USER SETTINGS:
```
"css.validate": false, // Disable css built-in lint
"stylelint.enable": true, // Enable sytlelint
```
> Paste these lines into a file called .stylelintrc in your project's root directory, create it if it does not exist. More information about stylelint's configuration follow this link: https://stylelint.io/user-guide/
```
{
  "extends": "stylelint-config-recommended",
  "rules": {
    "at-rule-no-unknown": [ true, {
      "ignoreAtRules": [
        "extends",
        "tailwind"
      ]
    }],
    "block-no-empty": null,
    "unit-whitelist": ["em", "rem", "s"]
  }
}
```
